### PR TITLE
Fix a carriage return on the query.

### DIFF
--- a/Db.class.php
+++ b/Db.class.php
@@ -167,7 +167,7 @@ class DB
 	*/			
 		public function query($query,$params = null, $fetchmode = PDO::FETCH_ASSOC)
 		{
-			$query = trim($query);
+			$query = trim(str_replace("\r", " ", $query));
 
 			$this->Init($query,$params);
 


### PR DESCRIPTION
Fix a carriage return on the query.
The trim function is not deleting '\r' character, so I added str_replace to remove.

<pre>
$sql = "SELECT
*
FROM 
persons";
</pre>
The SQL above would return null without str_replace.