### PR TITLE
转码修正（Transcoding correction）

### DIFF
--- a/Db.class.php
+++ b/Db.class.php
@@ -139,7 +139,7 @@ class DB
 	*/	
 		public function bind($para, $value)
 		{	
-			$this->parameters[sizeof($this->parameters)] = ":" . $para . "\x7F" . utf8_encode($value);
+			$this->parameters[sizeof($this->parameters)] = ":" . $para . "\x7F" . $value;
 		}
        /**
 	*	@void


### PR DESCRIPTION
避免已经是UTF-8的字符串再次被转码
用于：解决使用中文传递的问题

Avoid already is UTF-8 string to be transcoded again
To: solve problems using Chinese as UTF-8