### PR TITLE
Update Db.class.php

### DIFF
--- a/Db.class.php
+++ b/Db.class.php
@@ -139,7 +139,7 @@ class DB
 	*/	
 		public function bind($para, $value)
 		{	
-			$this->parameters[sizeof($this->parameters)] = ":" . $para . "\x7F" . utf8_encode($value);
+			$this->parameters[sizeof($this->parameters)] = ":" . $para . "\x7F" . $value;
 		}
        /**
 	*	@void


### PR DESCRIPTION
The utf8_encode() has generated errors for languages like Chinese.  so the utf8_encode() has been removed and the code reverted.